### PR TITLE
add options to set recommended packages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: SCTORvalidation
 Type: Package
 Title: Tools for assisting with package validation within the SCTO package
     validation projedct of the Statistics and Methodology platform
-Version: 0.4.4
+Version: 0.4.5
 Authors@R: 
     c(
     person(given = "Alan G.", family = "Haynes", role = "cre",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# SCTORvalidation 0.4.5
+
+Two new parameters were added to the check_session() function to allow to ignore the check of specified packages. 
+
 # SCTORvalidation 0.4.4
 
 Bug fix:
@@ -6,7 +10,7 @@ Bug fix:
 
 # SCTORvalidation 0.4.3
 
-`extract_elements_test` uses laxy regex to extract OS. It previously used greedy regex which caused issues when a package also loaded the Matrix package
+`extract_elements_test` uses lazy regex to extract OS. It previously used greedy regex which caused issues when a package also loaded the Matrix package
 
 # SCTORvalidation 0.4.2
 

--- a/R/check_session.R
+++ b/R/check_session.R
@@ -16,7 +16,9 @@
 check_session <- function(product_risk = c("low", "medium", "high"),
                           attached_only = TRUE, approved_only = TRUE, recommended = FALSE, ignore = NA){
   attached <- package <- loadedversion <- NULL
+  
 
+  
   # session info
   session <- package_info()
   session_info <- sessionInfo()
@@ -33,7 +35,7 @@ rec_list <- c("KernSmooth", "MASS", "Matrix", "boot", "class", "cluster", "codet
 if(!recommended)
     loaded <- loaded |> filter(!packages %in% rec_list)
 
-if(!is.na(ignore)){
+if(!is.na(ignore))
   loaded <- loaded |> filter(!packages %in% ignore)
 
   

--- a/R/check_session.R
+++ b/R/check_session.R
@@ -14,7 +14,7 @@
 #' check_session()
 #' }
 check_session <- function(product_risk = c("low", "medium", "high"),
-                          attached_only = TRUE, approved_only = TRUE){
+                          attached_only = TRUE, approved_only = TRUE, recommended = FALSE, ignore = NA){
   attached <- package <- loadedversion <- NULL
 
   # session info
@@ -27,6 +27,16 @@ check_session <- function(product_risk = c("low", "medium", "high"),
     # filter(attached) |>
     as.data.frame()
 
+
+rec_list <- c("KernSmooth", "MASS", "Matrix", "boot", "class", "cluster", "codetools", "foreign", 
+              "lattice", "mgcv", "nlme", "nnet", "rpart", "spatial", "survival")
+if(!recommended)
+    loaded <- loaded |> filter(!packages %in% rec_list)
+
+if(!is.na(ignore)){
+  loaded <- loaded |> filter(!packages %in% ignore)
+
+  
   if(attached_only)
     loaded <- loaded |> filter(attached)
 

--- a/R/check_session.R
+++ b/R/check_session.R
@@ -5,6 +5,8 @@
 #' @param product_risk character vector, which product risk levels should be included in the report (default: c("low", "medium", "high"))
 #' @param attached_only logical, should all loaded packages be shown (FALSE; default), or only those that are attached (TRUE)
 #' @param approved_only logical, should only validated (approved) packages be shown (TRUE; default), or also those awaiting approval (FALSE)
+#' @param recommended logical, should recommended packages be checked (FALSE; default)
+#' @param ignore character vector, packages to ignore during checking (NA; default)
 #' @export
 #' @importFrom sessioninfo package_info
 #' @importFrom dplyr filter left_join join_by first mutate summarize if_else across select
@@ -16,9 +18,9 @@
 check_session <- function(product_risk = c("low", "medium", "high"),
                           attached_only = TRUE, approved_only = TRUE, recommended = FALSE, ignore = NA){
   attached <- package <- loadedversion <- NULL
-  
 
-  
+
+
   # session info
   session <- package_info()
   session_info <- sessionInfo()
@@ -30,7 +32,7 @@ check_session <- function(product_risk = c("low", "medium", "high"),
     as.data.frame()
 
 
-rec_list <- c("KernSmooth", "MASS", "Matrix", "boot", "class", "cluster", "codetools", "foreign", 
+rec_list <- c("KernSmooth", "MASS", "Matrix", "boot", "class", "cluster", "codetools", "foreign",
               "lattice", "mgcv", "nlme", "nnet", "rpart", "spatial", "survival")
 if(!recommended)
     loaded <- loaded |> filter(!packages %in% rec_list)
@@ -38,7 +40,7 @@ if(!recommended)
 if(!is.na(ignore))
   loaded <- loaded |> filter(!packages %in% ignore)
 
-  
+
   if(attached_only)
     loaded <- loaded |> filter(attached)
 

--- a/man/check_session.Rd
+++ b/man/check_session.Rd
@@ -8,7 +8,9 @@
 check_session(
   product_risk = c("low", "medium", "high"),
   attached_only = TRUE,
-  approved_only = TRUE
+  approved_only = TRUE,
+  recommended = FALSE,
+  ignore = NA
 )
 
 \method{print}{sctovalidity}(x, ...)
@@ -19,6 +21,10 @@ check_session(
 \item{attached_only}{logical, should all loaded packages be shown (FALSE; default), or only those that are attached (TRUE)}
 
 \item{approved_only}{logical, should only validated (approved) packages be shown (TRUE; default), or also those awaiting approval (FALSE)}
+
+\item{recommended}{logical, should recommended packages be checked (FALSE; default)}
+
+\item{ignore}{character vector, packages to ignore during checking (NA; default)}
 
 \item{x}{output from \code{check_session}}
 


### PR DESCRIPTION
Add a way to remove the recommended packages (e.g. stats, nlme, survival, ...) from the checks that check_session does, e.g. option recommended = FALSE as default, similar to the attached_only argument.
Add a way to remove specific packages (ignore = NA) from the recommended list.
